### PR TITLE
Attack fixes and trinket menu pausing

### DIFF
--- a/Assets/Prefabs/Player/ChimeraVS.prefab
+++ b/Assets/Prefabs/Player/ChimeraVS.prefab
@@ -141,7 +141,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 6475537260892632208}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: -0.79067385, y: -13.547934, z: 0.52291864}
+  m_LocalEulerAnglesHint: {x: -0.7906754, y: -13.547932, z: 0.52291864}
 --- !u!1 &440610899011287430
 GameObject:
   m_ObjectHideFlags: 0
@@ -489,7 +489,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 7120051725487143016}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 47.176712, y: 0, z: 0}
 --- !u!1 &697410764355380136
 GameObject:
   m_ObjectHideFlags: 0
@@ -624,7 +624,7 @@ Transform:
   - {fileID: 673262635192024369}
   m_Father: {fileID: 5436882052127001281}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: -50.54831, y: -23.496603, z: -61.92493}
+  m_LocalEulerAnglesHint: {x: -75.1236, y: 165.90813, z: 98.337395}
 --- !u!1 &762443224488175223
 GameObject:
   m_ObjectHideFlags: 0
@@ -1432,7 +1432,7 @@ Transform:
   - {fileID: 531779791760150876}
   m_Father: {fileID: 4270369969382920112}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 39.672375, y: -7.6139164, z: -19.016874}
+  m_LocalEulerAnglesHint: {x: 12.66832, y: -61.142567, z: -78.75875}
 --- !u!1 &1268627170049391402
 GameObject:
   m_ObjectHideFlags: 0
@@ -1678,7 +1678,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 7120051725487143016}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0.0009250641, y: 6.5111737, z: 2.317598}
 --- !u!1 &1640650084521797000
 GameObject:
   m_ObjectHideFlags: 0
@@ -1709,7 +1709,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 7595948373520244346}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0.97663146, y: 162.3616, z: 179.51674}
+  m_LocalEulerAnglesHint: {x: 0.97662944, y: 162.3616, z: 179.51674}
 --- !u!1 &1681585754787029664
 GameObject:
   m_ObjectHideFlags: 0
@@ -1774,7 +1774,7 @@ Transform:
   - {fileID: 1257249482367830157}
   m_Father: {fileID: 752057984344897875}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0.17566156, y: 154.00095, z: 130.19926}
+  m_LocalEulerAnglesHint: {x: 21.258152, y: -143.8984, z: 119.882774}
 --- !u!1 &1889638662782591597
 GameObject:
   m_ObjectHideFlags: 0
@@ -1799,7 +1799,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1889638662782591597}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0.1, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1948,7 +1948,7 @@ Transform:
   - {fileID: 4812517622697349996}
   m_Father: {fileID: 1257249482367830157}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: -59.53124, y: -138.71127, z: 49.927547}
+  m_LocalEulerAnglesHint: {x: -14.457353, y: -106.24538, z: 33.5811}
 --- !u!1 &2307230582699748017
 GameObject:
   m_ObjectHideFlags: 0
@@ -2488,7 +2488,7 @@ Transform:
   - {fileID: 3780155620073892321}
   m_Father: {fileID: 4270369969382920112}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: -27.093235, y: -176.95314, z: 168.69682}
+  m_LocalEulerAnglesHint: {x: -8.673457, y: -177.87968, z: 157.58775}
 --- !u!1 &3047811335271670910
 GameObject:
   m_ObjectHideFlags: 0
@@ -3180,7 +3180,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 7120051725487143016}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 8.491569, y: -23.742012, z: -4.733675}
+  m_LocalEulerAnglesHint: {x: 20.93599, y: 37.872097, z: -16.724478}
 --- !u!1 &3373601479683406638
 GameObject:
   m_ObjectHideFlags: 0
@@ -3315,7 +3315,7 @@ Transform:
   - {fileID: 8640668170793566870}
   m_Father: {fileID: 1423098162149222122}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: -0.31580126, y: 18.243956, z: 1.3919736}
+  m_LocalEulerAnglesHint: {x: -0.015889883, y: 2.0066986, z: 0.9045222}
 --- !u!1 &3448316737192234984
 GameObject:
   m_ObjectHideFlags: 0
@@ -3507,7 +3507,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 7120051725487143016}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: -16.38046, y: -7.0922837, z: -33.99738}
+  m_LocalEulerAnglesHint: {x: 46.313908, y: -1.6209022, z: -7.8293}
 --- !u!1 &3886064911780067998
 GameObject:
   m_ObjectHideFlags: 0
@@ -4071,7 +4071,7 @@ Transform:
   - {fileID: 4585391653819130557}
   m_Father: {fileID: 3009440694786060674}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: -31.613317, y: -61.431557, z: 6.2201324}
+  m_LocalEulerAnglesHint: {x: 4.374835, y: 8.938475, z: -59.061726}
 --- !u!1 &4594758420240113667
 GameObject:
   m_ObjectHideFlags: 0
@@ -5016,7 +5016,7 @@ Transform:
   - {fileID: 6020086860601669184}
   m_Father: {fileID: 3137066822335597065}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: -9.3491535, y: 17.53916, z: 69.41223}
+  m_LocalEulerAnglesHint: {x: -62.07752, y: 121.78725, z: -36.80878}
 --- !u!1 &5011419947534072416
 GameObject:
   m_ObjectHideFlags: 0
@@ -5048,7 +5048,7 @@ Transform:
   - {fileID: 3009440694786060674}
   m_Father: {fileID: 5296504330546637535}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: -25.085613, y: 40.798885, z: 8.186239}
+  m_LocalEulerAnglesHint: {x: -3.0877788, y: -26.04898, z: 65.635445}
 --- !u!1 &5193703571362879086
 GameObject:
   m_ObjectHideFlags: 0
@@ -5518,7 +5518,7 @@ Transform:
   - {fileID: 6475537260892632208}
   m_Father: {fileID: 1727529980899670698}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0.4574666, y: 87.16791, z: 125.15346}
+  m_LocalEulerAnglesHint: {x: 21.674366, y: -173.7818, z: 87.68332}
 --- !u!1 &6112148988183812780
 GameObject:
   m_ObjectHideFlags: 0
@@ -6369,7 +6369,7 @@ Transform:
   - {fileID: 865760508072513655}
   m_Father: {fileID: 6020086860601669184}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: -19.213224, y: -19.568605, z: -76.592285}
+  m_LocalEulerAnglesHint: {x: 17.451368, y: -31.707817, z: -99.1022}
 --- !u!1 &6760450074781414939
 GameObject:
   m_ObjectHideFlags: 0
@@ -6876,7 +6876,7 @@ Transform:
   - {fileID: 7595948373520244346}
   m_Father: {fileID: 531779791760150876}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0.18065172, y: 108.86806, z: 125.84663}
+  m_LocalEulerAnglesHint: {x: 13.2821455, y: -172.61552, z: 100.1819}
 --- !u!1 &7093546307543263855
 GameObject:
   m_ObjectHideFlags: 0
@@ -7116,7 +7116,7 @@ Transform:
   - {fileID: 5436882052127001281}
   m_Father: {fileID: 3811446299041934847}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0.4221583, y: -178.11996, z: 129.44568}
+  m_LocalEulerAnglesHint: {x: 34.41127, y: -128.21269, z: 127.923676}
 --- !u!1 &7241229300102131595
 GameObject:
   m_ObjectHideFlags: 0
@@ -7447,7 +7447,7 @@ Transform:
   - {fileID: 51589725001361132}
   m_Father: {fileID: 5266473178221976047}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: -61.87622, y: 137.41374, z: -143.2637}
+  m_LocalEulerAnglesHint: {x: -52.744244, y: 95.68414, z: -107.3657}
 --- !u!1 &7597477608641955808
 GameObject:
   m_ObjectHideFlags: 0
@@ -7859,7 +7859,7 @@ Transform:
   - {fileID: 7379457303028710281}
   m_Father: {fileID: 3780155620073892321}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 58.59404, y: 164.75365, z: -3.6339722}
+  m_LocalEulerAnglesHint: {x: 76.6464, y: -150.06471, z: -173.1345}
 --- !u!1 &8128562432352675495
 GameObject:
   m_ObjectHideFlags: 0
@@ -7994,7 +7994,7 @@ Transform:
   - {fileID: 8889031875377882292}
   m_Father: {fileID: 51589725001361132}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 31.431816, y: -177.18797, z: 0.6689606}
+  m_LocalEulerAnglesHint: {x: 13.364021, y: -178.51279, z: 135.78435}
 --- !u!1 &8254035178640799379
 GameObject:
   m_ObjectHideFlags: 0
@@ -8688,7 +8688,7 @@ Transform:
   - {fileID: 6997687293468706141}
   m_Father: {fileID: 9083233087798648118}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: -0.36716655, y: 20.091684, z: 1.4364235}
+  m_LocalEulerAnglesHint: {x: -1.0617387, y: 38.9038, z: 1.6829596}
 --- !u!1 &8822501005264255226
 GameObject:
   m_ObjectHideFlags: 0
@@ -8929,7 +8929,7 @@ Transform:
   - {fileID: 1727529980899670698}
   m_Father: {fileID: 4270369969382920112}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 22.163485, y: 0.59773105, z: 166.42255}
+  m_LocalEulerAnglesHint: {x: -42.659855, y: -66.93875, z: -89.092094}
 --- !u!1 &9100769891403049231
 GameObject:
   m_ObjectHideFlags: 0
@@ -8954,7 +8954,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9100769891403049231}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0, y: 0.1, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Prefabs/VFX/Particle Effects/Rhino Slam/Slam VFX 1.prefab
+++ b/Assets/Prefabs/VFX/Particle Effects/Rhino Slam/Slam VFX 1.prefab
@@ -4935,7 +4935,7 @@ ParticleSystem:
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
   emitterVelocityMode: 1
-  looping: 1
+  looping: 0
   prewarm: 0
   playOnAwake: 1
   useUnscaledTime: 0

--- a/Assets/Rendering/3D Assets/Chimera/ChimeraWCRG/Anims/GroundSlam_R.anim
+++ b/Assets/Rendering/3D Assets/Chimera/ChimeraWCRG/Anims/GroundSlam_R.anim
@@ -38375,7 +38375,7 @@ AnimationClip:
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
   m_Events:
-  - time: 0.45833334
+  - time: 0.41666666
     functionName: RightAttack
     data: 
     objectReferenceParameter: {fileID: 0}

--- a/Assets/Scenes/Dungeon-Combat-Room.unity
+++ b/Assets/Scenes/Dungeon-Combat-Room.unity
@@ -484,6 +484,16 @@ PrefabInstance:
       propertyPath: m_Name
       value: ChimeraVS
       objectReference: {fileID: 0}
+    - target: {fileID: 4826133526552363418, guid: 398e09c0f65fb944889f7c64bd605ad5,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7433155870146330783, guid: 398e09c0f65fb944889f7c64bd605ad5,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8638392938306188172, guid: 398e09c0f65fb944889f7c64bd605ad5,
         type: 3}
       propertyPath: m_RootOrder
@@ -2813,6 +2823,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 2057520917}
     m_Modifications:
+    - target: {fileID: 3393498428562727267, guid: 2d15178f811f329459b95825ae797977,
+        type: 3}
+      propertyPath: m_AmplitudeGain
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4941362262552473576, guid: 2d15178f811f329459b95825ae797977,
         type: 3}
       propertyPath: m_RootOrder
@@ -2873,6 +2888,16 @@ PrefabInstance:
       propertyPath: m_Follow
       value: 
       objectReference: {fileID: 1179038559}
+    - target: {fileID: 5995439869381636702, guid: 2d15178f811f329459b95825ae797977,
+        type: 3}
+      propertyPath: m_Lens.OrthographicSize
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 6247087535629327205, guid: 2d15178f811f329459b95825ae797977,
+        type: 3}
+      propertyPath: orthographic size
+      value: 11
+      objectReference: {fileID: 0}
     - target: {fileID: 7424185672918931353, guid: 2d15178f811f329459b95825ae797977,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/Abstract Classes/Arm.cs
+++ b/Assets/Scripts/Abstract Classes/Arm.cs
@@ -16,7 +16,7 @@ public abstract class Arm : Limb
     private float attackDamage;
     private float attackSpeed;
 
-    private static GameObject attackRangeParent;
+    private GameObject attackRangeParent;
     
     //Hidden properties
 
@@ -79,7 +79,7 @@ public abstract class Arm : Limb
         // Create the attack range parent
         if (attackRangeParent == null)
         {
-            Transform parent = Weight == Weight.Light ? PlayerController.Instance.transform : null;
+            Transform parent = Weight == Weight.Light || Weight == Weight.Core ? PlayerController.Instance.transform : null;
             attackRangeParent = Instantiate(new GameObject(), parent);
             attackRangeParent.name = "Attack Range Pool";
         }

--- a/Assets/Scripts/Limbs/Arms/AttackRange.cs
+++ b/Assets/Scripts/Limbs/Arms/AttackRange.cs
@@ -33,6 +33,11 @@ public class AttackRange : MonoBehaviour
         transform.localScale = Vector3.one;
     }
 
+    private void OnDisable()
+    {
+        AttackEnded?.Invoke();
+    }
+
     private void DisableAttackRange()
     {
         AttackEnded?.Invoke();

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -337,7 +337,7 @@ public class PlayerController : Singleton<PlayerController>
     {
         movementValues = _movement.ReadValue<Vector2>();
         movementDir = movementValues.y * _mainCamera.transform.forward + movementValues.x * _mainCamera.transform.right;
-        Vector3 movementVector = new Vector3(movementDir.x, 0, movementDir.z);
+        Vector3 movementVector = new Vector3(movementDir.x, 0, movementDir.z).normalized;
         _controller.Move(movementVector * Time.deltaTime * _movementSpeed);
 
         animator.SetFloat("Speed", movementValues.magnitude * _movementSpeed / 10f);
@@ -447,7 +447,8 @@ public class PlayerController : Singleton<PlayerController>
         switch (arm.Weight)
         {
             case Weight.Core:
-            _movementSpeed *= 0.5f;
+                DisableAttackControls();
+                _movementSpeed *= 0.5f;
                 animator.SetTrigger("BaseAttack");
                 break;
             case Weight.Heavy: // Covers croc + rhino, but not shark (may need to be a ground slam instead???)
@@ -462,7 +463,7 @@ public class PlayerController : Singleton<PlayerController>
                 break;
             case Weight.Light:
                 DisableAttackControls();
-                _movementSpeed *= 0.3f;
+                _movementSpeed *= 0.5f;
                 animator.SetTrigger("LightAttack");
                 break;
         }

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -507,8 +507,6 @@ public class PlayerController : Singleton<PlayerController>
 
     private void EnableTrinketMenu()
     {
-        DisableAllDefaultControls();
-        EnableAllUIControls();
         NewTrinketManager.Instance.gameObject.SetActive(true);
     }
 

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -507,6 +507,8 @@ public class PlayerController : Singleton<PlayerController>
 
     private void EnableTrinketMenu()
     {
+        DisableAllDefaultControls();
+        EnableAllUIControls();
         NewTrinketManager.Instance.gameObject.SetActive(true);
     }
 

--- a/Assets/Scripts/Systems/Managers/GameManager.cs
+++ b/Assets/Scripts/Systems/Managers/GameManager.cs
@@ -13,7 +13,6 @@ public class GameManager : Singleton<GameManager>
     private void OnEnable()
     {
         PlayerController.OnGamePaused += PauseGame;
-        PlayerController.ToggleMenuPause += PauseGame;
         UIManager.ResumePressed += UnpauseGame;
         UIManager.QuitPressed += QuitGame;
     }
@@ -21,7 +20,6 @@ public class GameManager : Singleton<GameManager>
     private void OnDisable()
     {
         PlayerController.OnGamePaused -= PauseGame;
-        PlayerController.ToggleMenuPause -= PauseGame;
         UIManager.ResumePressed -= UnpauseGame;
         UIManager.QuitPressed -= QuitGame;
     }

--- a/Assets/Scripts/Trinkets/NewTrinketManager.cs
+++ b/Assets/Scripts/Trinkets/NewTrinketManager.cs
@@ -44,7 +44,8 @@ public class NewTrinketManager : Singleton<NewTrinketManager>
         EventSystem.current.SetSelectedGameObject(OptionOneGO);
 
         Invoke("debug", 1);
-        PlayerController.Instance.Pause();
+        PlayerController.Instance.DisableAllDefaultControls();
+        PlayerController.Instance.EnableAllUIControls();
 
         trinketOne = masterTrinketList.GetRandomTrinket();
         trinketTwo = masterTrinketList.GetRandomTrinket();


### PR DESCRIPTION
- game does not pause when trinket menu is enabled (controller support works again)
- attack pools now go to the correct pivot on L/R arms (my bad)
- slam attacks spawn above ground again