### PR TITLE
Updated drop colliders and fixed drop indicators

### DIFF
--- a/Assets/Prefabs/Drops/Limb Drops/Mammalian/RhinoArmDrop.prefab
+++ b/Assets/Prefabs/Drops/Limb Drops/Mammalian/RhinoArmDrop.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 2654534315462975498}
   - component: {fileID: 3653024600277252923}
   - component: {fileID: 213544860972622858}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: Rhino_Arm_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -93,10 +93,10 @@ GameObject:
   m_Component:
   - component: {fileID: 6523781888698248655}
   - component: {fileID: 6718459261893513183}
-  - component: {fileID: 6778618636064483117}
   - component: {fileID: 1669952791111070830}
+  - component: {fileID: 6778618636064483117}
   - component: {fileID: 4876641304011081291}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: RhinoArmDrop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -148,6 +148,30 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 112
   m_CollisionDetection: 0
+--- !u!114 &1669952791111070830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7937426487983829427}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd97a848e55974c4e9e957f98f3009d4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spreadsOnSpawn: 1
+  spreadDistance: 2
+  flingsOnSpawn: 1
+  flingSpeed: 97
+  upwardForce: 43
+  pickupIndicator: {fileID: 5346577193801738122}
+  weight: 0
+  classification: 0
+  type: 1
+  limbName: 3
+  limbCost: 75
+  limbSprite: {fileID: 21300000, guid: aa1fed58fc7bf884f8398e7a7a360128, type: 3}
 --- !u!65 &6778618636064483117
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -169,29 +193,6 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 3, y: 5, z: 3}
   m_Center: {x: 0, y: 3, z: 0}
---- !u!114 &1669952791111070830
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7937426487983829427}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd97a848e55974c4e9e957f98f3009d4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spreadsOnSpawn: 1
-  spreadDistance: 2
-  flingsOnSpawn: 1
-  flingSpeed: 97
-  upwardForce: 43
-  weight: 0
-  classification: 0
-  type: 1
-  limbName: 3
-  limbCost: 75
-  limbSprite: {fileID: 21300000, guid: aa1fed58fc7bf884f8398e7a7a360128, type: 3}
 --- !u!65 &4876641304011081291
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -205,7 +206,7 @@ BoxCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 64
+    m_Bits: 8256
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
@@ -225,6 +226,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Loot Drop
+      objectReference: {fileID: 0}
+    - target: {fileID: 487859658420665908, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 2045317860842234213, guid: 2664cef1edddb9d4d9db647e950bae14,
         type: 3}
@@ -316,6 +322,11 @@ PrefabInstance:
       propertyPath: m_PropertySheet.m_Vector4f.m_Array.Array.data[0].m_Overridden
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6029165676769356145, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -342,8 +353,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6538770454011260829, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 7397749335219711842, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
@@ -410,6 +431,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8653117299461033140, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -421,3 +447,15 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 7408684722158173499}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5346577193801738122 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3234204799244704433, guid: a05b4b7448a800d40943d9dfd290fecb,
+    type: 3}
+  m_PrefabInstance: {fileID: 7408684722158173499}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0175badece64f0349a564ad214cf1f28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Drops/Limb Drops/Mammalian/RhinoHeadDrop.prefab
+++ b/Assets/Prefabs/Drops/Limb Drops/Mammalian/RhinoHeadDrop.prefab
@@ -10,10 +10,10 @@ GameObject:
   m_Component:
   - component: {fileID: 6088907435053944671}
   - component: {fileID: 8219082950152308669}
-  - component: {fileID: 3075094490775034245}
   - component: {fileID: 1581230926361960152}
+  - component: {fileID: 3075094490775034245}
   - component: {fileID: 3844430002903048603}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: RhinoHeadDrop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -65,6 +65,30 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 112
   m_CollisionDetection: 0
+--- !u!114 &1581230926361960152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2603748985196018749}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd97a848e55974c4e9e957f98f3009d4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spreadsOnSpawn: 1
+  spreadDistance: 2
+  flingsOnSpawn: 1
+  flingSpeed: 97
+  upwardForce: 43
+  pickupIndicator: {fileID: 6418088467732241770}
+  weight: 0
+  classification: 0
+  type: 0
+  limbName: 3
+  limbCost: 0
+  limbSprite: {fileID: 0}
 --- !u!65 &3075094490775034245
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -86,29 +110,6 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 3, y: 5, z: 3}
   m_Center: {x: 0, y: 3, z: 0}
---- !u!114 &1581230926361960152
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2603748985196018749}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd97a848e55974c4e9e957f98f3009d4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spreadsOnSpawn: 1
-  spreadDistance: 2
-  flingsOnSpawn: 1
-  flingSpeed: 97
-  upwardForce: 43
-  weight: 0
-  classification: 0
-  type: 0
-  limbName: 3
-  limbCost: 0
-  limbSprite: {fileID: 0}
 --- !u!65 &3844430002903048603
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -122,7 +123,7 @@ BoxCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 64
+    m_Bits: 8256
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
@@ -141,7 +142,7 @@ GameObject:
   - component: {fileID: 8387527693438088254}
   - component: {fileID: 5628377553257457708}
   - component: {fileID: 3292363277896529252}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: Rhino_Head
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -225,6 +226,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Loot Drop
+      objectReference: {fileID: 0}
+    - target: {fileID: 487859658420665908, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 2045317860842234213, guid: 2664cef1edddb9d4d9db647e950bae14,
         type: 3}
@@ -316,6 +322,11 @@ PrefabInstance:
       propertyPath: m_PropertySheet.m_Vector4f.m_Array.Array.data[0].m_Overridden
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6029165676769356145, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -342,8 +353,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6538770454011260829, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 7397749335219711842, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
@@ -450,6 +471,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8653117299461033140, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -461,3 +487,15 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 8499301117940598747}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &6418088467732241770 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3234204799244704433, guid: a05b4b7448a800d40943d9dfd290fecb,
+    type: 3}
+  m_PrefabInstance: {fileID: 8499301117940598747}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0175badece64f0349a564ad214cf1f28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Drops/Limb Drops/Mammalian/WolfArmDrop.prefab
+++ b/Assets/Prefabs/Drops/Limb Drops/Mammalian/WolfArmDrop.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 1116198844490198364}
   - component: {fileID: 6422848831184760907}
   - component: {fileID: 2396686290583257146}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: Wolf_Arm_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -93,10 +93,10 @@ GameObject:
   m_Component:
   - component: {fileID: 703859972947461443}
   - component: {fileID: 6608880605014765258}
-  - component: {fileID: 3244514245376401728}
   - component: {fileID: 7998381026548464130}
+  - component: {fileID: 3244514245376401728}
   - component: {fileID: 6143212846419447494}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: WolfArmDrop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -148,6 +148,30 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 112
   m_CollisionDetection: 0
+--- !u!114 &7998381026548464130
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8465967043707308671}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd97a848e55974c4e9e957f98f3009d4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spreadsOnSpawn: 1
+  spreadDistance: 2
+  flingsOnSpawn: 1
+  flingSpeed: 83
+  upwardForce: 56
+  pickupIndicator: {fileID: 7301383429535651797}
+  weight: 2
+  classification: 0
+  type: 1
+  limbName: 0
+  limbCost: 60
+  limbSprite: {fileID: 21300000, guid: aee2ab2ef12c91748b0ee3a7cfb07650, type: 3}
 --- !u!65 &3244514245376401728
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -169,29 +193,6 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 3, y: 5, z: 3}
   m_Center: {x: 0, y: 3, z: 0}
---- !u!114 &7998381026548464130
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8465967043707308671}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd97a848e55974c4e9e957f98f3009d4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spreadsOnSpawn: 1
-  spreadDistance: 2
-  flingsOnSpawn: 1
-  flingSpeed: 83
-  upwardForce: 56
-  weight: 2
-  classification: 0
-  type: 1
-  limbName: 0
-  limbCost: 60
-  limbSprite: {fileID: 21300000, guid: aee2ab2ef12c91748b0ee3a7cfb07650, type: 3}
 --- !u!65 &6143212846419447494
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -205,7 +206,7 @@ BoxCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 64
+    m_Bits: 8256
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
@@ -228,8 +229,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6538770454011260829, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 7397749335219711842, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
@@ -296,6 +307,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8653117299461033140, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -307,6 +323,18 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 5310181198738050404}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &7301383429535651797 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3234204799244704433, guid: a05b4b7448a800d40943d9dfd290fecb,
+    type: 3}
+  m_PrefabInstance: {fileID: 5310181198738050404}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0175badece64f0349a564ad214cf1f28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &7089628602690571741
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -319,6 +347,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Loot Drop
+      objectReference: {fileID: 0}
+    - target: {fileID: 487859658420665908, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 2045317860842234213, guid: 2664cef1edddb9d4d9db647e950bae14,
         type: 3}
@@ -409,6 +442,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_PropertySheet.m_Vector4f.m_Array.Array.data[0].m_Overridden
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6029165676769356145, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Prefabs/Drops/Limb Drops/Mammalian/WolfLegsDrop.prefab
+++ b/Assets/Prefabs/Drops/Limb Drops/Mammalian/WolfLegsDrop.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 336955029031111433}
   - component: {fileID: 3573168968631109587}
   - component: {fileID: 5733100358252878131}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: WolfLegsDrop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -56,6 +56,7 @@ MonoBehaviour:
   flingsOnSpawn: 1
   flingSpeed: 0
   upwardForce: 0
+  pickupIndicator: {fileID: 8801783516793959754}
   weight: 2
   classification: 0
   type: 2
@@ -123,7 +124,7 @@ BoxCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 8256
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
@@ -142,7 +143,7 @@ GameObject:
   - component: {fileID: 6590192487991138022}
   - component: {fileID: 4685374509059518929}
   - component: {fileID: 1424945496084783119}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: WolfLeg_L (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -226,7 +227,7 @@ GameObject:
   - component: {fileID: 6123069584775766647}
   - component: {fileID: 3069631497145910904}
   - component: {fileID: 3417639391184463207}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: WolfLegHair2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -309,7 +310,7 @@ GameObject:
   - component: {fileID: 5660451508632116968}
   - component: {fileID: 4552600903494252624}
   - component: {fileID: 7577611534642429300}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: WolfLeg_R (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -393,7 +394,7 @@ GameObject:
   - component: {fileID: 6668061512343185702}
   - component: {fileID: 6078978094783553496}
   - component: {fileID: 2687932248608333044}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: WolfLegHair
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -477,6 +478,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Loot Drop
+      objectReference: {fileID: 0}
+    - target: {fileID: 487859658420665908, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 1610312602487570492, guid: 2664cef1edddb9d4d9db647e950bae14,
         type: 3}
@@ -573,6 +579,11 @@ PrefabInstance:
       propertyPath: m_PropertySheet.m_Vector4f.m_Array.Array.data[0].m_Overridden
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6029165676769356145, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -599,8 +610,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6538770454011260829, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 7397749335219711842, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
@@ -667,6 +688,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8653117299461033140, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -678,3 +704,15 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 6252125861768359931}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &8801783516793959754 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3234204799244704433, guid: a05b4b7448a800d40943d9dfd290fecb,
+    type: 3}
+  m_PrefabInstance: {fileID: 6252125861768359931}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0175badece64f0349a564ad214cf1f28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Drops/Limb Drops/Reptilian/CrocArmDrop.prefab
+++ b/Assets/Prefabs/Drops/Limb Drops/Reptilian/CrocArmDrop.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 2654534315462975498}
   - component: {fileID: 3653024600277252923}
   - component: {fileID: 213544860972622858}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: Croc_Arm_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -93,10 +93,10 @@ GameObject:
   m_Component:
   - component: {fileID: 6523781888698248655}
   - component: {fileID: 6718459261893513183}
-  - component: {fileID: 6778618636064483117}
   - component: {fileID: 1669952791111070830}
+  - component: {fileID: 6778618636064483117}
   - component: {fileID: 4876641304011081291}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: CrocArmDrop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -148,6 +148,30 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 112
   m_CollisionDetection: 0
+--- !u!114 &1669952791111070830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7937426487983829427}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd97a848e55974c4e9e957f98f3009d4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spreadsOnSpawn: 1
+  spreadDistance: 2
+  flingsOnSpawn: 1
+  flingSpeed: 70
+  upwardForce: 49
+  pickupIndicator: {fileID: 4894967901608422122}
+  weight: 0
+  classification: 1
+  type: 1
+  limbName: 1
+  limbCost: 50
+  limbSprite: {fileID: 21300000, guid: 18fb43f679b6f1e40ba063392ccce1d3, type: 3}
 --- !u!65 &6778618636064483117
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -169,29 +193,6 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 3, y: 5, z: 3}
   m_Center: {x: 0, y: 3, z: 0}
---- !u!114 &1669952791111070830
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7937426487983829427}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd97a848e55974c4e9e957f98f3009d4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spreadsOnSpawn: 1
-  spreadDistance: 2
-  flingsOnSpawn: 1
-  flingSpeed: 70
-  upwardForce: 49
-  weight: 0
-  classification: 1
-  type: 1
-  limbName: 1
-  limbCost: 50
-  limbSprite: {fileID: 21300000, guid: 18fb43f679b6f1e40ba063392ccce1d3, type: 3}
 --- !u!65 &4876641304011081291
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -205,7 +206,7 @@ BoxCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 64
+    m_Bits: 8256
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
@@ -225,6 +226,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Loot Drop
+      objectReference: {fileID: 0}
+    - target: {fileID: 487859658420665908, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 1610312602487570492, guid: 2664cef1edddb9d4d9db647e950bae14,
         type: 3}
@@ -321,6 +327,11 @@ PrefabInstance:
       propertyPath: m_PropertySheet.m_Vector4f.m_Array.Array.data[0].m_Overridden
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6029165676769356145, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -347,8 +358,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6538770454011260829, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 7397749335219711842, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
@@ -415,10 +436,20 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 8653117299461033140, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 3234204799244704433, guid: a05b4b7448a800d40943d9dfd290fecb, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4894967901608422122}
   m_SourcePrefab: {fileID: 100100000, guid: a05b4b7448a800d40943d9dfd290fecb, type: 3}
 --- !u!224 &1750888806748166312 stripped
 RectTransform:
@@ -426,3 +457,21 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 9144134376744400842}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &6486751726988752183 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
+    type: 3}
+  m_PrefabInstance: {fileID: 9144134376744400842}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4894967901608422122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6486751726988752183}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0175badece64f0349a564ad214cf1f28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Drops/Limb Drops/Reptilian/CrocLegsDrop.prefab
+++ b/Assets/Prefabs/Drops/Limb Drops/Reptilian/CrocLegsDrop.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1698830263675789389}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: Models
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -44,7 +44,7 @@ GameObject:
   - component: {fileID: 3092823201532479433}
   - component: {fileID: 5979952967255250641}
   - component: {fileID: 1695052971456201924}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: CrocLegTransition_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -127,7 +127,7 @@ GameObject:
   - component: {fileID: 5443683061992785626}
   - component: {fileID: 7216362158405397513}
   - component: {fileID: 4254359875684107945}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: CrocLeg_R
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -212,7 +212,7 @@ GameObject:
   - component: {fileID: 2676897641746812931}
   - component: {fileID: 5196896523879327977}
   - component: {fileID: 4610166875102524396}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: FootClaw_R
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -297,7 +297,7 @@ GameObject:
   - component: {fileID: 336955029031111433}
   - component: {fileID: 3573168968631109587}
   - component: {fileID: 5733100358252878131}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: CrocLegsDrop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -339,6 +339,7 @@ MonoBehaviour:
   flingsOnSpawn: 1
   flingSpeed: 30
   upwardForce: 59
+  pickupIndicator: {fileID: 4656894527383773285}
   weight: 0
   classification: 1
   type: 2
@@ -406,7 +407,7 @@ BoxCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 8256
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
@@ -425,7 +426,7 @@ GameObject:
   - component: {fileID: 8294598537040872700}
   - component: {fileID: 5219842760559062798}
   - component: {fileID: 2856121672072312747}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: CrocLeg_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -510,7 +511,7 @@ GameObject:
   - component: {fileID: 8539290946185373167}
   - component: {fileID: 1330749360611943246}
   - component: {fileID: 6277602562515105940}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: FootClaw_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -593,7 +594,7 @@ GameObject:
   - component: {fileID: 2389625735345314736}
   - component: {fileID: 5185704779442029667}
   - component: {fileID: 8379570187927920018}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: CrocLegTransition_R
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -677,6 +678,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Loot Drop
+      objectReference: {fileID: 0}
+    - target: {fileID: 487859658420665908, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 1610312602487570492, guid: 2664cef1edddb9d4d9db647e950bae14,
         type: 3}
@@ -773,6 +779,11 @@ PrefabInstance:
       propertyPath: m_PropertySheet.m_Vector4f.m_Array.Array.data[0].m_Overridden
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6029165676769356145, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -799,8 +810,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6538770454011260829, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 7397749335219711842, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
@@ -867,10 +888,20 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 8653117299461033140, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 3234204799244704433, guid: a05b4b7448a800d40943d9dfd290fecb, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4656894527383773285}
   m_SourcePrefab: {fileID: 100100000, guid: a05b4b7448a800d40943d9dfd290fecb, type: 3}
 --- !u!224 &3489751551115477145 stripped
 RectTransform:
@@ -878,3 +909,21 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 6252125861768359931}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &8225803621718371590 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
+    type: 3}
+  m_PrefabInstance: {fileID: 6252125861768359931}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4656894527383773285
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8225803621718371590}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0175badece64f0349a564ad214cf1f28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Drops/Limb Drops/Reptilian/GeckoArmDrop.prefab
+++ b/Assets/Prefabs/Drops/Limb Drops/Reptilian/GeckoArmDrop.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 1913788197453138403}
   - component: {fileID: 3363909580986957210}
   - component: {fileID: 2591206205946271377}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckArm_L (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -94,10 +94,10 @@ GameObject:
   m_Component:
   - component: {fileID: 2768634352585879418}
   - component: {fileID: 952462279069997666}
-  - component: {fileID: 2243717749598149906}
   - component: {fileID: 9172008504814477055}
+  - component: {fileID: 2243717749598149906}
   - component: {fileID: 2088174164489037308}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: GeckoArmDrop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -149,6 +149,30 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 112
   m_CollisionDetection: 0
+--- !u!114 &9172008504814477055
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3583152938891452061}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd97a848e55974c4e9e957f98f3009d4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spreadsOnSpawn: 1
+  spreadDistance: 2
+  flingsOnSpawn: 1
+  flingSpeed: 70
+  upwardForce: 49
+  pickupIndicator: {fileID: 1045908588095100936}
+  weight: 2
+  classification: 1
+  type: 1
+  limbName: 2
+  limbCost: 20
+  limbSprite: {fileID: 21300000, guid: 12a24fb0d30358e40910ea1df5c55202, type: 3}
 --- !u!65 &2243717749598149906
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -170,29 +194,6 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 3, y: 5, z: 3}
   m_Center: {x: 0, y: 3, z: 0}
---- !u!114 &9172008504814477055
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3583152938891452061}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd97a848e55974c4e9e957f98f3009d4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spreadsOnSpawn: 1
-  spreadDistance: 2
-  flingsOnSpawn: 1
-  flingSpeed: 70
-  upwardForce: 49
-  weight: 2
-  classification: 1
-  type: 1
-  limbName: 2
-  limbCost: 20
-  limbSprite: {fileID: 21300000, guid: 12a24fb0d30358e40910ea1df5c55202, type: 3}
 --- !u!65 &2088174164489037308
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -206,7 +207,7 @@ BoxCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 64
+    m_Bits: 8256
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
@@ -225,7 +226,7 @@ GameObject:
   - component: {fileID: 5184238871808995710}
   - component: {fileID: 6897381932941167654}
   - component: {fileID: 1037426081744587299}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckFingers_L2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -308,7 +309,7 @@ GameObject:
   - component: {fileID: 1092562848940658663}
   - component: {fileID: 5075809629002847297}
   - component: {fileID: 6254449905099128389}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckFingers_L1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -389,7 +390,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1215175046518028851}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckFingies_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -427,7 +428,7 @@ GameObject:
   - component: {fileID: 8006106513943399602}
   - component: {fileID: 8214026503555694370}
   - component: {fileID: 5285762892211735209}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckFingers_L4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -510,7 +511,7 @@ GameObject:
   - component: {fileID: 2308797041219235910}
   - component: {fileID: 7473570452582370832}
   - component: {fileID: 8649582638143666263}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckFingers_L3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -593,7 +594,7 @@ GameObject:
   - component: {fileID: 1674983891652669411}
   - component: {fileID: 1647419118313822584}
   - component: {fileID: 233880847124726116}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckFingers_L5
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -677,6 +678,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Loot Drop
+      objectReference: {fileID: 0}
+    - target: {fileID: 487859658420665908, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 2045317860842234213, guid: 2664cef1edddb9d4d9db647e950bae14,
         type: 3}
@@ -768,6 +774,11 @@ PrefabInstance:
       propertyPath: m_PropertySheet.m_Vector4f.m_Array.Array.data[0].m_Overridden
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6029165676769356145, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -794,8 +805,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6538770454011260829, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 7397749335219711842, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
@@ -902,11 +923,28 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8653117299461033140, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a05b4b7448a800d40943d9dfd290fecb, type: 3}
+--- !u!114 &1045908588095100936 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3234204799244704433, guid: a05b4b7448a800d40943d9dfd290fecb,
+    type: 3}
+  m_PrefabInstance: {fileID: 2477512443361247929}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0175badece64f0349a564ad214cf1f28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &4957321499750919643 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7397749335219711842, guid: a05b4b7448a800d40943d9dfd290fecb,

--- a/Assets/Prefabs/Drops/Limb Drops/Reptilian/GeckoLegsDrop.prefab
+++ b/Assets/Prefabs/Drops/Limb Drops/Reptilian/GeckoLegsDrop.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 2970847265971819549}
   - component: {fileID: 5282610490420073401}
   - component: {fileID: 1831036786621797679}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckToes_L5
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -94,7 +94,7 @@ GameObject:
   - component: {fileID: 4002272458111426531}
   - component: {fileID: 8775785479004019744}
   - component: {fileID: 7298161008590994227}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: Models
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -174,7 +174,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6683151242549733692}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckToes_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -212,7 +212,7 @@ GameObject:
   - component: {fileID: 2908284027400625681}
   - component: {fileID: 6782667908081461228}
   - component: {fileID: 3075814662852877442}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckToes_L4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -295,7 +295,7 @@ GameObject:
   - component: {fileID: 8588245819430343602}
   - component: {fileID: 8294726733666816004}
   - component: {fileID: 3866717155730761855}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckToes_L1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -378,7 +378,7 @@ GameObject:
   - component: {fileID: 2099450934764913221}
   - component: {fileID: 8526514466234806458}
   - component: {fileID: 3048438993645829803}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckToes_L2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -461,7 +461,7 @@ GameObject:
   - component: {fileID: 7326075257981109811}
   - component: {fileID: 1049037154379706662}
   - component: {fileID: 3540104331976529844}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckToes_L3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -544,7 +544,7 @@ GameObject:
   - component: {fileID: 6348469613979421325}
   - component: {fileID: 1273637984168505207}
   - component: {fileID: 4365436443558769383}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckLeg_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -628,7 +628,7 @@ GameObject:
   - component: {fileID: 4109742673828034306}
   - component: {fileID: 6357183539022945168}
   - component: {fileID: 7861606991069946006}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckToe2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -711,7 +711,7 @@ GameObject:
   - component: {fileID: 4785829907443301592}
   - component: {fileID: 4266345647345608359}
   - component: {fileID: 3888323253488232743}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckToe5
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -794,7 +794,7 @@ GameObject:
   - component: {fileID: 3218014099839112647}
   - component: {fileID: 1947455452700153379}
   - component: {fileID: 6195376080054533738}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckToe4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -877,7 +877,7 @@ GameObject:
   - component: {fileID: 1639800706976240501}
   - component: {fileID: 5341831639547890923}
   - component: {fileID: 3918317973448408498}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckToe1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -958,7 +958,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6160186213419102859}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckLegs (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -993,7 +993,7 @@ GameObject:
   - component: {fileID: 4337472990330029341}
   - component: {fileID: 1739885614616061520}
   - component: {fileID: 3958494816170730894}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckToe3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1074,7 +1074,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1081733151903360742}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckToesR
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1112,7 +1112,7 @@ GameObject:
   - component: {fileID: 9120380138034764851}
   - component: {fileID: 1487601480439120673}
   - component: {fileID: 998251724476072249}
-  m_Layer: 6
+  m_Layer: 13
   m_Name: GeckLeg_R
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1197,7 +1197,8 @@ GameObject:
   - component: {fileID: 2167596114594638700}
   - component: {fileID: 3676439032642074792}
   - component: {fileID: 2834140594199804696}
-  m_Layer: 6
+  - component: {fileID: 5494649172294795165}
+  m_Layer: 13
   m_Name: GeckoLegsDrop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1230,7 +1231,7 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8372370546128528112}
   serializedVersion: 4
-  m_Mass: 1
+  m_Mass: 10
   m_Drag: 0
   m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}
@@ -1247,7 +1248,7 @@ Rigidbody:
   m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 126
+  m_Constraints: 112
   m_CollisionDetection: 0
 --- !u!114 &3676439032642074792
 MonoBehaviour:
@@ -1266,6 +1267,7 @@ MonoBehaviour:
   flingsOnSpawn: 1
   flingSpeed: 114
   upwardForce: 38
+  pickupIndicator: {fileID: 2979624812244823652}
   weight: 2
   classification: 1
   type: 2
@@ -1293,6 +1295,27 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 3, y: 5, z: 3}
   m_Center: {x: 0, y: 3, z: 0}
+--- !u!65 &5494649172294795165
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8372370546128528112}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 8256
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &413193016498648277
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1308,8 +1331,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6538770454011260829, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 7397749335219711842, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
@@ -1416,11 +1449,28 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8653117299461033140, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a05b4b7448a800d40943d9dfd290fecb, type: 3}
+--- !u!114 &2979624812244823652 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3234204799244704433, guid: a05b4b7448a800d40943d9dfd290fecb,
+    type: 3}
+  m_PrefabInstance: {fileID: 413193016498648277}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0175badece64f0349a564ad214cf1f28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &7138734311841586103 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7397749335219711842, guid: a05b4b7448a800d40943d9dfd290fecb,
@@ -1439,6 +1489,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Loot Drop
+      objectReference: {fileID: 0}
+    - target: {fileID: 487859658420665908, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 1610312602487570492, guid: 2664cef1edddb9d4d9db647e950bae14,
         type: 3}
@@ -1544,6 +1599,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_PropertySheet.m_Vector4f.m_Array.Array.data[0].m_Overridden
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6029165676769356145, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Prefabs/Drops/TrinketBag.prefab
+++ b/Assets/Prefabs/Drops/TrinketBag.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 2751763087240608077}
   - component: {fileID: 8607698037403157643}
   - component: {fileID: 1632779909246558967}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: TrinketBag
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -76,6 +76,7 @@ MonoBehaviour:
   flingsOnSpawn: 1
   flingSpeed: 70
   upwardForce: 70
+  pickupIndicator: {fileID: 8871321608833642096}
 --- !u!54 &8607698037403157643
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -116,7 +117,7 @@ BoxCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 64
+    m_Bits: 8256
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
@@ -136,6 +137,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Loot Drop
+      objectReference: {fileID: 0}
+    - target: {fileID: 487859658420665908, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 1610312602487570492, guid: 2664cef1edddb9d4d9db647e950bae14,
         type: 3}
@@ -237,6 +243,11 @@ PrefabInstance:
       propertyPath: m_PropertySheet.m_Vector4f.m_Array.Array.data[0].m_Overridden
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6029165676769356145, guid: 2664cef1edddb9d4d9db647e950bae14,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -263,8 +274,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2658231638124217085, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6538770454011260829, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 7397749335219711842, guid: a05b4b7448a800d40943d9dfd290fecb,
         type: 3}
@@ -331,6 +352,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8653117299461033140, guid: a05b4b7448a800d40943d9dfd290fecb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -342,6 +368,18 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 6340910087986394305}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &8871321608833642096 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3234204799244704433, guid: a05b4b7448a800d40943d9dfd290fecb,
+    type: 3}
+  m_PrefabInstance: {fileID: 6340910087986394305}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0175badece64f0349a564ad214cf1f28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &6976837937819570877
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -434,6 +472,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: TrinketBag_low
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: dfa4000c0539f47378bee80f1e5c930d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/Drops/Drop.cs
+++ b/Assets/Scripts/Drops/Drop.cs
@@ -8,22 +8,21 @@ public class Drop : MonoBehaviour
     [SerializeField] protected bool spreadsOnSpawn = true;
     [SerializeField] protected float spreadDistance = 2f;
     [SerializeField] protected bool flingsOnSpawn = true;
-    [SerializeField] [Range(0, 1000)] protected float flingSpeed;
-    [SerializeField] [Range(0, 1000)] protected float upwardForce;
+    [SerializeField][Range(0, 1000)] protected float flingSpeed;
+    [SerializeField][Range(0, 1000)] protected float upwardForce;
 
-    PickupIndicator pickupIndicator;
+    [SerializeField] PickupIndicator pickupIndicator;
 
     private void OnEnable()
     {
         DebugControls.DestroyAllDrops += DestroyDrop;
-        pickupIndicator = GetComponentInChildren<PickupIndicator>(true);
     }
 
     private void OnDisable()
     {
         DebugControls.DestroyAllDrops -= DestroyDrop;
     }
-    
+
     private void Start()
     {
         DetermineDropSpawn();
@@ -37,7 +36,7 @@ public class Drop : MonoBehaviour
 
     private void DetermineDropSpawn()
     {
-        Vector3 spreadXZ = PointOnXZCircle(transform.position, spreadDistance, Random.Range(0,360)).normalized;
+        Vector3 spreadXZ = PointOnXZCircle(transform.position, spreadDistance, Random.Range(0, 360)).normalized;
 
         if (spreadsOnSpawn && !flingsOnSpawn)
             transform.position = spreadXZ;


### PR DESCRIPTION
All drops have two colliders
One for triggering pickup
One for not falling through the floor
Collider for not falling through the floor ignores layers Player and Drop

Pickup indicators were serialized and referenced in editor